### PR TITLE
[Issue {#32}]Add clustering models inside single_model_dict

### DIFF
--- a/tab_automl/automl/models.py
+++ b/tab_automl/automl/models.py
@@ -49,6 +49,7 @@ single_model_dict = {
         "MeanShift": MeanShift,
         "OPTICS": OPTICS,
         "SpectralClustering": SpectralClustering,
-        "GaussianMixture": GaussianMixture
+        "GaussianMixture": GaussianMixture,
+        "HierarchicalDivisiveClustering": HierarchicalDivisiveClustering
     }
 }


### PR DESCRIPTION
Changes made
Adding Hierarchical Divisive Clustering to models.py

Description
The divisive clustering algorithm is a top-down clustering approach, initially, all the points in the dataset belong to one cluster and split is performed recursively as one moves down the hierarchy.